### PR TITLE
Fix typo

### DIFF
--- a/kvoptions.dtx
+++ b/kvoptions.dtx
@@ -546,7 +546,7 @@ and the derived files
 % \end{declcs}
 % Both macros mark package options as local options. That means
 % that they are ignored by \cs{ProcessKeyvalOptions} if they are given
-% as global options. \cs{DeclareLocalOptions} takes one option,
+% as global options. \cs{DeclareLocalOption} takes one option,
 % \cs{DeclareLocalOptions} expects a comma-separated list of options.
 %
 % \subsubsection{Dynamic options}


### PR DESCRIPTION
* kvoptions.dtx (subsubsection{Local options}): Fix name of \DeclareLocalOption which takes only one option.